### PR TITLE
Failing Xcode Previews when ScanbotSDK integrated

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,6 +9,7 @@ let package = Package(
     products: [
         .library(
             name: "ScanbotSDK",
+            type: .static,
             targets: ["ScanbotSDK"]),
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -9,6 +9,7 @@ let package = Package(
     products: [
         .library(
             name: "ScanbotSDK",
+            type: .dynamic,
             targets: ["ScanbotSDK"]),
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,6 @@ let package = Package(
     products: [
         .library(
             name: "ScanbotSDK",
-            type: .dynamic,
             targets: ["ScanbotSDK"]),
     ],
     targets: [


### PR DESCRIPTION
### This pull request is not a fix. It is just way to report critical bug it terms of using Xcode Previews and ScanbotSDK at the same time.

#### Environment:
- Xcode Version 14.0.1 (14A400)
- ScanbotSDK 1.31.0

#### Steps to reproduce:
1. Create **Hello World** app
2. Try to run **Xcode Previews** in **ContentView.swift** file -> It is working fine.
3. Add **ScanbotSDK** as SPM
4. Try to run **Xcode Previews** -> It is failing with an error.

### Error message:
`SettingsError: noExecutablePath(<IDESwiftPackageStaticLibraryProductBuildable:ObjectIdentifier(0x00006000322ca190):'ScanbotSDK'>)`

Here is discussion in Apple Developer Forums about this type of error: https://developer.apple.com/forums/thread/707569